### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,7 +5,6 @@ authors = ["Shtoyan"]
 description = "Map lists for KF1 objective based gametypes."
 src = "src"
 language = "en"
-multilingual = false
 
 [build]
 build-dir = "book"


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10